### PR TITLE
docs: add Awareness Goldilocks suite + wire STATE references

### DIFF
--- a/awareness/STATE.md
+++ b/awareness/STATE.md
@@ -53,4 +53,9 @@
 - Full awareness required for AI
 
 ---
-*Auto-update: Daily at 02:00 UTC*
+*Auto-update: Daily at 02:00 UTC*`n## REFERENCES
+- /docs/ai-awareness/SPARKS.md
+- /docs/ai-awareness/DECISIONS.md
+- /docs/ai-awareness/THRESHOLDS.md
+- /docs/ai-awareness/METRICS_SNAPSHOT.md
+- /docs/ai-awareness/AIM.md

--- a/docs/ai-awareness/AIM.md
+++ b/docs/ai-awareness/AIM.md
@@ -1,0 +1,20 @@
+# AIM - Awareness Index Map
+
+## Purpose
+Awareness Index Map — index-first pathing
+
+## Document Index
+
+| Doc | Tier (CORE/SUPP/DEEP) | Tokens (approx) | Last-Updated | Purpose/When to read |
+| --- | --- | --- | --- | --- |
+| STATE | CORE | 300 | 2025-08-23 | System state, current sprint |
+| OPERATIONS | CORE | 150 | 2025-08-28 | TLS renewal, AI workflow rules |
+| MVP_REQUIREMENTS | CORE | 4000 | 2025-08-28 | Launch requirements, P0 blockers |
+| NOW | SUPP | 500 | 2025-01 | Current status, next steps |
+| STATUS | SUPP | 800 | 2025-07 | Project status, achievements |
+| NEXT | SUPP | 400 | - | Sprint queue, P0 actions |
+| HANDOFF | SUPP | 600 | 2025-08-22 | AI collaboration notes |
+| SPARKS | DEEP | 200 | 2025-08-28 | Raw ideas, weekly cull |
+| DECISIONS | DEEP | 100 | 2025-08-29 | ADR-lite, settled questions |
+| THRESHOLDS | DEEP | 150 | 2025-08-29 | Pre-commit triggers |
+| METRICS_SNAPSHOT | DEEP | 200 | 2025-08-29 | Scoreboard, 2×/week updates |

--- a/docs/ai-awareness/DECISIONS.md
+++ b/docs/ai-awareness/DECISIONS.md
@@ -1,0 +1,15 @@
+# DECISIONS - ADR-lite Ledger
+
+## Purpose
+ADR-lite format to stop re-deciding settled questions.
+
+## Template (copyable)
+ADR-### — YYYY-MM-DD — Owner
+Decision:
+Rationale (trade-offs):
+Status: Active | Superseded by ADR-___
+Review on:
+Links: (PRs, work log anchors)
+
+## Open Decisions
+(empty - add decisions as they arise)

--- a/docs/ai-awareness/METRICS_SNAPSHOT.md
+++ b/docs/ai-awareness/METRICS_SNAPSHOT.md
@@ -1,0 +1,15 @@
+# METRICS_SNAPSHOT - One-page Scoreboard
+
+## Purpose
+One-page scoreboard; update 2×/week
+
+## Current Metrics
+
+| Metric | Value | Trend (↑/→/↓) | Note | As-of |
+| --- | --- | --- | --- | --- |
+| Signups | - | - | - | - |
+| Weekly Active | - | - | - | - |
+| Trial→Paid % | - | - | - | - |
+| P0 Burn-down | - | - | - | - |
+| Response Latency | - | - | - | - |
+| Bootup Time | - | - | - | - |

--- a/docs/ai-awareness/SPARKS.md
+++ b/docs/ai-awareness/SPARKS.md
@@ -1,0 +1,23 @@
+# SPARKS - Raw Idea Spring
+
+## Purpose
+- Capture unfiltered ideas in one-liners
+- Raw inspiration, not polished plans
+- Weekly cull/promote 1-2 to active projects
+- Keep entries short and dated
+
+## Current Sparks (2025-08-28)
+• LIQUID_METAL.md → vision: awareness+reflexes+structure fused  
+• Shadow sparks list → capture in chat; pour weekly  
+• Memory hygiene ritual → cadence, pruning questions, tripwires  
+• Awareness efficiency simulation → validate AIM + MSC pathing  
+• Imagination factory metaphor → garage → ideas/dreams line  
+• Goldilocks bundle → SPARKS, DECISIONS, THRESHOLDS, METRICS, AIM  
+• 30-year Christmas table vision (legacy anchor)  
+• Reflex triggers tied to habits (sleep/binge)  
+• Resonance → sync deploy cadence with personal reset cycles
+
+## Notes
+- Keep entries to one line maximum
+- Date-stamp new additions  
+- Weekly review: cull stale, promote 1-2 actionable

--- a/docs/ai-awareness/THRESHOLDS.md
+++ b/docs/ai-awareness/THRESHOLDS.md
@@ -1,0 +1,11 @@
+# THRESHOLDS - Pre-commit Triggers
+
+## Purpose
+Pre-commit objective triggers → auto-actions to NEXT
+
+## Active Thresholds
+
+| Name | Signal | Threshold | Auto-Action | Owner | Notes |
+| --- | --- | --- | --- | --- | --- |
+<!-- example --> | Hydration Drift | Bootup time | >4 min two days | Add task "Reduce hydration" | Tyler | tighten AIM |
+<!-- example --> | Release Slippage | P0 overdue | >48h late | Re-scope or add help | Ops | escalate in NEXT |


### PR DESCRIPTION
- Adds five awareness docs:
  - docs/ai-awareness/SPARKS.md (seeded)
  - docs/ai-awareness/DECISIONS.md
  - docs/ai-awareness/THRESHOLDS.md
  - docs/ai-awareness/METRICS_SNAPSHOT.md
  - docs/ai-awareness/AIM.md
- Wires awareness/STATE.md with a ## REFERENCES section linking the five docs.
- Docs-only change; no code paths touched.
