### PR TITLE
docs(process): note role-policy change (Cursor primary, Sonnet audits-only) in NOW/STATUS

### DIFF
--- a/NOW.md
+++ b/NOW.md
@@ -1,0 +1,4 @@
+<!-- Process note: 2025-09-04 -->
+> Collaboration roles updated: **Cursor = primary executor (code/git/deploy)**; **Sonnet = audits/intel/codebase search only**; **Opus removed**. Prompt labeling enforced; explicitly call out Tyler-required steps.
+
+

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,4 @@
+<!-- Process note: 2025-09-04 -->
+**Collaboration Policy Update:** Cursor is the primary executor for code/git/deploy; Sonnet limited to audits/intel/codebase search. Opus removed. Prompts will clearly label the target and call out Tyler actions.
+
+


### PR DESCRIPTION
**Change:** Document collaboration role policy (Cursor primary executor; Sonnet audits/intel-only; Opus removed).
**Files:** NOW.md, STATUS.md (prepended process notes).
**Why:** Aligns repo docs with current working model to reduce confusion and ensure prompts/ownership are clear.
**Merge:** Safe to merge in next batch window (docs-only).