### PR TITLE
chore(guards): enforce local-only workspace (ignore, CI guard)

### DIFF
--- a/.github/workflows/local-guard.yml
+++ b/.github/workflows/local-guard.yml
@@ -1,0 +1,13 @@
+name: Local Guard
+on: [push, pull_request]
+jobs:
+  local_guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Local workspace guard
+        run: |
+          if [ $(git ls-files -- local/ | wc -l) -gt 0 ]; then
+            echo "Tracked files under local/ are forbidden."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ routes/**/*.bak
 routes/**/*.save
 routes/**/*~
 routes/**/*.orig
+/local/
+/local/**
+/local/
+/local/**


### PR DESCRIPTION
Adds /local/ ignore rules, machine-local excludes, pre-commit hooks (installed locally), and a CI guard job to fail if any tracked file appears under local/**. No local/* files committed.